### PR TITLE
removal of SpecDM checks

### DIFF
--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_defibrillator.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_defibrillator.lua
@@ -151,7 +151,7 @@ if SERVER then
 			return
 		end
 
-		if ply:IsActive() and not (SpecDM and not ply:IsGhost()) then
+		if ply:IsActive() then
 			self:Error(DEFI_ERROR_PLAYER_ALIVE)
 
 			return
@@ -173,7 +173,7 @@ if SERVER then
 				end
 			end,
 			function(p)
-				if not p:IsActive() and (SpecDM and p:IsGhost()) then
+				if not p:IsActive() then
 					self:CancelRevival()
 					self:Error(DEFI_ERROR_PLAYER_ALIVE)
 					return false
@@ -255,7 +255,7 @@ if SERVER then
 		elseif not owner:KeyDown(IN_ATTACK) or owner:GetEyeTrace(MASK_SHOT_HULL).Entity ~= self.defiTarget then
 			self:CancelRevival()
 			self:Error(DEFI_ERROR_LOST_TARGET)
-		elseif target:IsActive() and not (SpecDM and not target:IsGhost()) then
+		elseif target:IsActive() then
 			self:CancelRevival()
 			self:Error(DEFI_ERROR_PLAYER_ALIVE)
 		end

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_defibrillator.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_defibrillator.lua
@@ -173,7 +173,7 @@ if SERVER then
 				end
 			end,
 			function(p)
-				if not p:IsActive() then
+				if p:IsActive() then
 					self:CancelRevival()
 					self:Error(DEFI_ERROR_PLAYER_ALIVE)
 					return false


### PR DESCRIPTION
To avoid a script error and to avoid confusion among the players why the dead player cannot be revived even though everyone knows that the player is dead and could be revived these SpecDM checks should be removed.