### PR TITLE
fixed IsReviving nil value issue

### DIFF
--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_defibrillator.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_defibrillator.lua
@@ -328,7 +328,7 @@ if SERVER then
 	net.Receive("RequestRevivalStatus", function(_, requester)
 		local ply = net.ReadEntity()
 
-		if not IsValid(ply) then return end
+		if not IsValid(ply) or not ply.IsReviving then return end
 
 		net.Start("ReceiveRevivalStatus")
 		net.WriteEntity(ply)


### PR DESCRIPTION
This fixes the following issue:
```
[[TTT2] Defibrillator [WEAPON]] gamemodes/terrortown/entities/weapons/weapon_ttt_defibrillator.lua:335: attempt to call method 'IsReviving' (a nil value)
  1. func - gamemodes/terrortown/entities/weapons/weapon_ttt_defibrillator.lua:335
   2. unknown - lua/includes/extensions/net.lua:38

[TTT2 (Base) - v0.13.2b] Warning! A net message (ReceiveRevivalStatus) is already started! Discarding in favor of the new message! (StartDrowning)
  1. StartDrowning - gamemodes/terrortown/gamemode/shared/sh_player_ext.lua:973
   2. unknown - gamemodes/terrortown/gamemode/shared/sh_main.lua:471
```
This should fix the errors and make the code more robust.