### PR TITLE
fixed revival issue

### DIFF
--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_defibrillator.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_defibrillator.lua
@@ -197,14 +197,19 @@ if SERVER then
         self:SetStartTime(CurTime())
         self:SetReviveTime(reviveTime)
         self:PlaySound("hum")
+        self.defiTarget = ragdoll
+        self.defiBone = bone
+
+        timer.Simple(reviveTime, function()
+            if not IsValid(self) or not IsValid(ply) or not IsValid(owner) then return end
+            self:FinishRevival(ply, owner)
+        end)
 
         -- start revival
         ply:Revive(reviveTime, function(p)
             if self.cvars.resetConfirmation:GetBool() then
-                ply:ResetConfirmPlayer()
+                p:ResetConfirmPlayer()
             end
-
-            self:FinishRevival(p, owner)
         end, function(p)
             if p:IsTerror() then
                 self:CancelRevival(p)
@@ -216,9 +221,6 @@ if SERVER then
             end
         end, true, REVIVAL_BLOCK_NONE)
         ply:SendRevivalReason(self.revivalReason, { name = self:GetOwner():Nick() })
-
-        self.defiTarget = ragdoll
-        self.defiBone = bone
     end
 
     function SWEP:FinishRevival(ply, owner)


### PR DESCRIPTION
Fixed an issue with the revival.
Even if the revival fails because the success chance is too low it still respawns the player even though an error appears and the owner still has the defi.
This happened because FinishRevival was called after the revival was already finished and therefore didn't cancel it even if the success chance was too low.